### PR TITLE
Added information for copying policy files from the host OS

### DIFF
--- a/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
+++ b/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
@@ -47,7 +47,7 @@ mypolicy.policy                                    100%  253     0.3KB/s   00:00
 
 Finally, the policy must be copied from its temporary location to the /telemetry/policies/ directory in the IOS XR filesystem:
 
-[xr-vm_node0_RP0_CPU0:~]$**cp /disk0\:/test/cpu.policy /telemetry/policies/**
+[xr-vm_node0_RP0_CPU0:~]$**cp /disk0\:/mypolicies/cpu.policy /telemetry/policies/**
 
 The policy is now loaded by IOS XR and is shown in the telemetry policy configuration:
 

--- a/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
+++ b/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
@@ -31,5 +31,33 @@ sftp> **quit**
 [xr-vm_node0_RP0_CPU0:~]$**cp /disk0:/BasicPolicy.policy /telemetry/policies**  
 [xr-vm_node0_RP0_CPU0:~]$  
 
+If you wish to copy a policy file from the host Linux operating system to the IOS XR filesystem within the Vagrant box, then there is a two-step process. Firstly, a writeable directory must be created in disk0:
 
+RP/0/RP0/CPU0:ios#**run**
+Tue Jun 28 06:40:16.346 UTC
+[xr-vm_node0_RP0_CPU0:~]$**cd /disk0\:**
+[xr-vm_node0_RP0_CPU0:~]$**mkdir mypolicies**
+[xr-vm_node0_RP0_CPU0:~]$**chmod 777 mypolicies**
+
+The policy file can then be copied using scp to the Vagrant IOS XR instance:
+
+user@host:~/vagrant/iosxrv> **scp -P 2222 mypolicy.policy vagrant@localhost:/disk0:/mypolicies/**
+vagrant@localhost's password: 
+mypolicy.policy                                    100%  253     0.3KB/s   00:00 
+
+Finally, the policy must be copied from its temporary location to the /telemetry/policies/ directory in the IOS XR filesystem:
+
+[xr-vm_node0_RP0_CPU0:~]$**cp /disk0\:/test/cpu.policy /telemetry/policies/**
+
+The policy is now loaded by IOS XR and is shown in the telemetry policy configuration:
+
+RP/0/RP0/CPU0:ios#**show telemetry policies**
+Tue Jun 28 07:36:39.125 UTC
+
+cpu
+  Filename:             cpu.policy
+  Version:              25
+  Description:          cpu
+  Status:               Active
+  [etc]
 

--- a/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
+++ b/_tutorials/2016-06-23-copying-telemetry-policy-files-in-ios-xr-6-0-1.md
@@ -76,17 +76,17 @@ Finally, the policy must be copied from its temporary location to the /telemetry
 <div class="highlighter-rouge">
 <pre class="highlight">
 <code>
-[xr-vm_node0_RP0_CPU0:~]$<mark>cp /disk0\:/mypolicies/cpu.policy /telemetry/policies/</mark>
+[xr-vm_node0_RP0_CPU0:~]$<mark>cp /disk0\:/mypolicies/mypolicy.policy /telemetry/policies/</mark>
 
 The policy is now loaded by IOS XR and is shown in the telemetry policy configuration:
 
 RP/0/RP0/CPU0:ios#<mark>show telemetry policies</mark>
 Tue Jun 28 07:36:39.125 UTC
 
-cpu
-  Filename:             cpu.policy
+mypolicy
+  Filename:             mypolicy.policy
   Version:              25
-  Description:          cpu
+  Description:          mypolicy
   Status:               Active
   [etc]
 </code>


### PR DESCRIPTION
I have added some information to describe how the user can copy policy files from the host OS to the XR Vagrantbox using scp. I have used 6.1.1.19I and tested.

The user needs to create a directory in disk0: with the correct permissions to write the policy file. The file can then be copied using scp. The file is then copied in the IOS XR run environment to the /telemetry/policies directory.

ricwade@cisco.com
